### PR TITLE
Splitting launcher & scoop

### DIFF
--- a/TeamCode/src/main/java/org/nknsd/teamcode/components/drivers/LauncherDriver.java
+++ b/TeamCode/src/main/java/org/nknsd/teamcode/components/drivers/LauncherDriver.java
@@ -34,24 +34,6 @@ public class LauncherDriver implements NKNComponent {
         }
     };
 
-    Runnable launchBall = new Runnable() {
-        @Override
-        public void run() {
-//            if (launcherHandler.getCurrentTps() < launcherTargetTPS) {
-//                return;
-//            }
-
-            launcherHandler.setScoopToLaunch(true);
-        }
-    };
-
-    Runnable resetScoop = new Runnable() {
-        @Override
-        public void run() {
-            launcherHandler.setScoopToLaunch(false);
-        }
-    };
-
     @Override
     public boolean init(Telemetry telemetry, HardwareMap hardwareMap, Gamepad gamepad1, Gamepad gamepad2) {
         return true;
@@ -66,8 +48,8 @@ public class LauncherDriver implements NKNComponent {
     public void start(ElapsedTime runtime, Telemetry telemetry) {
         gamePadHandler.addListener(controlScheme.spinUp(), spinUp, "Start spinning up");
         gamePadHandler.addListener(controlScheme.spinDown(), spinDown, "Release spin, start down");
-        gamePadHandler.addListener(controlScheme.launchBall(), launchBall, "Trigger a launch via the scoop");
-        gamePadHandler.addListener(controlScheme.resetScoop(), resetScoop, "Return the scoop to the down position");
+//        gamePadHandler.addListener(controlScheme.launchBall(), launchBall, "Trigger a launch via the scoop");
+//        gamePadHandler.addListener(controlScheme.resetScoop(), resetScoop, "Return the scoop to the down position");
     }
 
     @Override

--- a/TeamCode/src/main/java/org/nknsd/teamcode/components/handlers/LauncherHandler.java
+++ b/TeamCode/src/main/java/org/nknsd/teamcode/components/handlers/LauncherHandler.java
@@ -3,17 +3,12 @@ package org.nknsd.teamcode.components.handlers;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.Gamepad;
 import com.qualcomm.robotcore.hardware.HardwareMap;
-import com.qualcomm.robotcore.hardware.Servo;
 import com.qualcomm.robotcore.util.ElapsedTime;
-
 import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.nknsd.teamcode.frameworks.NKNComponent;
 
 public class LauncherHandler implements NKNComponent {
-    private TimedControlFlags timingFlag = TimedControlFlags.NO_FLAG; // flags that allow delayed control over the intake
-
     private DcMotor wMotor;
-    private Servo scoopServo;
     private boolean enabled;
     private double wPower;
 
@@ -23,8 +18,6 @@ public class LauncherHandler implements NKNComponent {
     private double previousRunTime = -1;
     private double ticks; // Idk what units ticks are in
     private double pFactor = 0.00001;
-    private double timeToDisable;
-    private MicrowaveHandler microwaveHandler;
 
     public void setTargetTps(double targetTps) {
        this.targetTps = targetTps;
@@ -33,21 +26,16 @@ public class LauncherHandler implements NKNComponent {
     @Override
     public boolean init(Telemetry telemetry, HardwareMap hardwareMap, Gamepad gamepad1, Gamepad gamepad2) {
         wMotor = hardwareMap.dcMotor.get("LM");
-        scoopServo = hardwareMap.servo.get("Scoop");
         wMotor.setPower(0);
         wPower = 1; // initial wPower is set to 1 so that the speed up is more aggressive initially
         return true;
     }
 
     @Override
-    public void init_loop(ElapsedTime runtime, Telemetry telemetry) {
-
-    }
+    public void init_loop(ElapsedTime runtime, Telemetry telemetry) {}
 
     @Override
-    public void start(ElapsedTime runtime, Telemetry telemetry) {
-        setScoopToLaunch(false);
-    }
+    public void start(ElapsedTime runtime, Telemetry telemetry) {}
 
     @Override
     public void stop(ElapsedTime runtime, Telemetry telemetry) {
@@ -61,22 +49,6 @@ public class LauncherHandler implements NKNComponent {
 
     @Override
     public void loop(ElapsedTime runtime, Telemetry telemetry) {
-        switch (timingFlag) {
-            case NO_SCOOP_CONTROL_START:
-                timeToDisable = runtime.milliseconds() + 500;
-                timingFlag = TimedControlFlags.NO_SCOOP_CONTROL;
-                break;
-
-            case NO_SCOOP_CONTROL:
-                if (runtime.milliseconds() > timeToDisable) {
-                    timingFlag = TimedControlFlags.NO_FLAG;
-                }
-                break;
-
-            default:
-                break;
-        }
-
         if (!enabled) {
             wMotor.setPower(0);
             //wPower = 0;
@@ -121,10 +93,9 @@ public class LauncherHandler implements NKNComponent {
 
     @Override
     public void doTelemetry(Telemetry telemetry) {
-//        telemetry.addData("wPower", wPower);
-//        telemetry.addData("currentTps", currentTps);
-//        telemetry.addData("targetTps", targetTps);
-        telemetry.addData("scoop pos", scoopServo.getPosition());
+        telemetry.addData("wPower", wPower);
+        telemetry.addData("currentTps", currentTps);
+        telemetry.addData("targetTps", targetTps);
     }
 
     public void setEnabled(boolean enabled){
@@ -136,39 +107,11 @@ public class LauncherHandler implements NKNComponent {
         }
     }
 
-    public boolean isScoopInLaunchPosition() {
-        return scoopServo.getPosition() == 1;
-    }
-
-    /**
-     * Controls the servo, allowing for the launching or defaulting of the scoop servo.
-     * @param launch = If true, sets the scoop to the launch position. If false, resets the scoop.
-     */
-    public void setScoopToLaunch(boolean launch) {
-        if (timingFlag == TimedControlFlags.NO_SCOOP_CONTROL || timingFlag == TimedControlFlags.NO_SCOOP_CONTROL_START) {
-            return;
-        }
-        if (microwaveHandler != null && !microwaveHandler.isInFirePosition()) {
-            return;
-        }
-        scoopServo.setPosition(launch ? 1 : 0.5);
-    }
-
     public double getCurrentTps() {
         return currentTps;
     }
 
-    public void setDisableFlag() {
-        timingFlag = TimedControlFlags.NO_SCOOP_CONTROL_START;
-    }
-
-    private enum TimedControlFlags {
-        NO_FLAG,
-        NO_SCOOP_CONTROL_START,
-        NO_SCOOP_CONTROL
-    }
-
     public void link(MicrowaveHandler microwaveHandler) {
-        this.microwaveHandler = microwaveHandler;
+
     }
 }

--- a/TeamCode/src/main/java/org/nknsd/teamcode/components/handlers/MicrowaveHandler.java
+++ b/TeamCode/src/main/java/org/nknsd/teamcode/components/handlers/MicrowaveHandler.java
@@ -19,7 +19,7 @@ public class MicrowaveHandler implements NKNComponent {
     Servo servo;
     ColourSensor.BallColor[] slotColors = new ColourSensor.BallColor[3];
     private IntakeHandler intakeHandler;
-    private LauncherHandler launcherHandler;
+    private ScoopHandler scoopHandler;
 
     enum MicroState {
         LOAD0(0.22),
@@ -35,10 +35,14 @@ public class MicrowaveHandler implements NKNComponent {
     }
 
     private void setState(MicroState state) {
-        if (launcherHandler != null && launcherHandler.isScoopInLaunchPosition()) {
+        if (state == servoState) {
             return;
         }
 
+        // if we failed to lock out the servo, return
+        if (scoopHandler != null && !scoopHandler.lockOutServo()) {
+            return;
+        }
 
         servo.setPosition(state.microPosition);
         servoState = state;
@@ -46,11 +50,6 @@ public class MicrowaveHandler implements NKNComponent {
         if (intakeHandler != null) {
             intakeHandler.toggleIntake(true);
             intakeHandler.setDisableFlag();
-        }
-
-        if (launcherHandler != null) {
-            launcherHandler.setScoopToLaunch(false);
-            launcherHandler.setDisableFlag();
         }
     }
     public void findIntakeColour(ColourSensor.BallColor color){
@@ -140,7 +139,11 @@ public class MicrowaveHandler implements NKNComponent {
     }
 
     public void link(LauncherHandler launcherHandler) {
-        this.launcherHandler = launcherHandler;
+//        this.launcherHandler = launcherHandler;
+    }
+
+    public void link(ScoopHandler scoopHandler) {
+        this.scoopHandler = scoopHandler;
     }
 
     public boolean isInFirePosition() {

--- a/TeamCode/src/main/java/org/nknsd/teamcode/components/handlers/ScoopHandler.java
+++ b/TeamCode/src/main/java/org/nknsd/teamcode/components/handlers/ScoopHandler.java
@@ -4,12 +4,9 @@ import com.qualcomm.robotcore.hardware.Gamepad;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.hardware.Servo;
 import com.qualcomm.robotcore.util.ElapsedTime;
-import com.qualcomm.robotcore.util.RobotLog;
 
 import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.nknsd.teamcode.frameworks.NKNStateBasedComponent;
-
-import java.util.concurrent.locks.Lock;
 
 public class ScoopHandler extends NKNStateBasedComponent {
     static final double SERVO_REST_POS = 0.5;
@@ -44,16 +41,25 @@ public class ScoopHandler extends NKNStateBasedComponent {
 
     }
 
+    // SETTERS
     void returnScoopToRest() {
         switchState(new RestState(scoopServo));
     }
-    public void triggerScoopToLaunch() {
-        switchState(new LaunchState(scoopServo, this));
+    public boolean triggerScoopToLaunch() {
+        return switchState(new LaunchState(scoopServo, this));
     }
-    public void lockOutServo() {
-        switchState(new LockedState(this));
+    public boolean lockOutServo() {
+        return switchState(new LockedState(this));
     }
 
+
+    // GETTERS
+    public boolean isInLaunch() {
+        return currentState.getClass() == LaunchState.class;
+    }
+
+
+    // STATES
     private class RestState extends State {
         private final Servo servo;
         RestState(Servo servo){
@@ -86,7 +92,12 @@ public class ScoopHandler extends NKNStateBasedComponent {
 
         @Override
         public void onStart() {
-            servo.setPosition(ScoopHandler.SERVO_LAUNCH_POS);
+            servo.setPosition(SERVO_LAUNCH_POS);
+        }
+
+        @Override
+        public void onStop() {
+            servo.setPosition(SERVO_REST_POS);
         }
 
         @Override

--- a/TeamCode/src/main/java/org/nknsd/teamcode/components/handlers/ScoopHandler.java
+++ b/TeamCode/src/main/java/org/nknsd/teamcode/components/handlers/ScoopHandler.java
@@ -1,0 +1,116 @@
+package org.nknsd.teamcode.components.handlers;
+
+import com.qualcomm.robotcore.hardware.Gamepad;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+import com.qualcomm.robotcore.hardware.Servo;
+import com.qualcomm.robotcore.util.ElapsedTime;
+import com.qualcomm.robotcore.util.RobotLog;
+
+import org.firstinspires.ftc.robotcore.external.Telemetry;
+import org.nknsd.teamcode.frameworks.NKNStateBasedComponent;
+
+import java.util.concurrent.locks.Lock;
+
+public class ScoopHandler extends NKNStateBasedComponent {
+    static final double SERVO_REST_POS = 0.5;
+    static final double SERVO_LAUNCH_POS = 1;
+
+    private Servo scoopServo;
+
+    @Override
+    public boolean init(Telemetry telemetry, HardwareMap hardwareMap, Gamepad gamepad1, Gamepad gamepad2) {
+        scoopServo = hardwareMap.servo.get("Scoop");
+        return true;
+    }
+
+    @Override
+    public void init_loop(ElapsedTime runtime, Telemetry telemetry) {
+
+    }
+
+    @Override
+    public void start(ElapsedTime runtime, Telemetry telemetry) {
+        returnScoopToRest();
+    }
+
+    @Override
+    public void stop(ElapsedTime runtime, Telemetry telemetry) {
+
+    }
+
+    @Override
+    public String getName() {
+        return "Scoop Handler";
+
+    }
+
+    void returnScoopToRest() {
+        switchState(new RestState(scoopServo));
+    }
+    public void triggerScoopToLaunch() {
+        switchState(new LaunchState(scoopServo, this));
+    }
+    public void lockOutServo() {
+        switchState(new LockedState(this));
+    }
+
+    private class RestState extends State {
+        private final Servo servo;
+        RestState(Servo servo){
+            this.servo = servo;
+        }
+        @Override
+        public boolean canSwitchToState(State state) {
+            return state.getClass() == LaunchState.class || state.getClass() == LockedState.class;
+        }
+
+        @Override
+        public void onStart() {
+            servo.setPosition(ScoopHandler.SERVO_REST_POS);
+        }
+    }
+    private class LaunchState extends TimingState {
+        private final Servo servo;
+        private final ScoopHandler master;
+
+        LaunchState(Servo servo, ScoopHandler master){
+            super(100);
+            this.servo = servo;
+            this.master = master;
+        }
+
+        @Override
+        public boolean canSwitchToState(State state) {
+            return state.getClass() == RestState.class;
+        }
+
+        @Override
+        public void onStart() {
+            servo.setPosition(ScoopHandler.SERVO_LAUNCH_POS);
+        }
+
+        @Override
+        protected void finishTimer() {
+            master.returnScoopToRest();
+        }
+    }
+    private class LockedState extends TimingState {
+        private final ScoopHandler master;
+
+        LockedState(ScoopHandler master){
+            super(500);
+            this.master = master;
+        }
+
+        @Override
+        public boolean canSwitchToState(State state) {
+            return state.getClass() == RestState.class;
+        }
+
+        @Override
+        protected void finishTimer() {
+            master.returnScoopToRest();
+        }
+    }
+
+}

--- a/TeamCode/src/main/java/org/nknsd/teamcode/frameworks/NKNStateBasedComponent.java
+++ b/TeamCode/src/main/java/org/nknsd/teamcode/frameworks/NKNStateBasedComponent.java
@@ -17,12 +17,14 @@ public abstract class NKNStateBasedComponent implements NKNComponent {
         currentState.doTelemetry();
     }
 
-    protected void switchState(State state) {
+    protected boolean switchState(State state) {
         if (currentState.canSwitchToState(state)) {
             currentState.onStop();
             currentState = state;
             currentState.onStart();
+            return true;
         }
+        return false;
     }
 
     protected abstract class State {

--- a/TeamCode/src/main/java/org/nknsd/teamcode/frameworks/NKNStateBasedComponent.java
+++ b/TeamCode/src/main/java/org/nknsd/teamcode/frameworks/NKNStateBasedComponent.java
@@ -5,26 +5,52 @@ import com.qualcomm.robotcore.util.ElapsedTime;
 import org.firstinspires.ftc.robotcore.external.Telemetry;
 
 public abstract class NKNStateBasedComponent implements NKNComponent {
-    protected State state;
+    protected State currentState;
 
     @Override
     public void loop(ElapsedTime runtime, Telemetry telemetry) {
-        state.run(runtime);
+        currentState.run(runtime);
     }
 
     @Override
     public void doTelemetry(Telemetry telemetry) {
-        state.doTelemetry();
+        currentState.doTelemetry();
     }
 
-    public abstract class State {
-        abstract boolean canSwitchToState(Class<State> state);
-        abstract void run(ElapsedTime runtime);
-        abstract void onStart(ElapsedTime runtime);
-        abstract void onStop(ElapsedTime runtime);
+    protected void switchState(State state) {
+        if (currentState.canSwitchToState(state)) {
+            currentState.onStop();
+            currentState = state;
+            currentState.onStart();
+        }
+    }
+
+    protected abstract class State {
+        public abstract boolean canSwitchToState(State state);
+        public void run(ElapsedTime runtime){}
+        public void onStart(){}
+        public void onStop(){}
         // provides a default so that lower states don't need to setup telem if they don't want to
         public void doTelemetry() {}
     }
 
+    protected abstract class TimingState extends State {
+        private double startTime = -1;
+        private final double resetTime;
+        protected TimingState(double resetTime) {
+            this.resetTime = resetTime;
+        }
+
+        abstract protected void finishTimer();
+        public void run(ElapsedTime runtime){
+            if (runtime.milliseconds() > startTime + resetTime) {
+                finishTimer();
+            }
+
+            if (startTime == -1) {
+                startTime = runtime.milliseconds();
+            }
+        }
+    }
 
 }


### PR DESCRIPTION
Split the launcher and the scoop classes!
The LauncherHandler no longer contains any code mentioning the scoop, as it has all been moved to ScoopHandler. 
LaunchDriver and MicrowaveHandler have been correctly adjusted to remove the code related to controlling scoop via launch handler.
Still working on a new ScoopDriver.